### PR TITLE
feat: add core models and DB schema for Aima v1

### DIFF
--- a/back/app/models/activity_log.rb
+++ b/back/app/models/activity_log.rb
@@ -1,0 +1,21 @@
+class ActivityLog < ApplicationRecord
+  enum :mood,      { energetic: 0, neutral: 1, calm: 2 }
+  enum :feedback,  { good: 0, normal: 1, bad: 2 }
+  enum :weather,   { sunny: 0, cloudy: 1, rainy: 2 }
+
+  before_validation :set_defaults, on: :create
+  
+  validates :mood, presence: true
+  validates :feedback, presence: true
+  validates :weather, presence: true
+  validates :duration_min, presence: true
+
+  belongs_to :user
+  belongs_to :recipe
+  
+  private
+
+  def set_defaults
+    self.feedback ||= :normal
+  end
+end

--- a/back/app/models/recipe.rb
+++ b/back/app/models/recipe.rb
@@ -1,0 +1,9 @@
+class Recipe < ApplicationRecord
+        enum :category, { relax: 0, focus: 1, outdoor: 2, reflect: 3, play: 4 }
+
+        validates :title, presence: true
+        validates :category, presence: true
+        validates :description, presence: true
+
+        has_many :activity_logs
+end

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -1,0 +1,19 @@
+class User < ApplicationRecord
+    enum :personality, { energetic: 0, neutral: 1, calm: 2 }
+    enum :preference,  { outdoor: 0, both: 1, indoor: 2 }
+
+    before_validation :set_defaults, on: :create
+
+    validates :personality, presence: true
+    validates :preference, presence: true
+
+    has_many :activity_logs, dependent: :destroy
+
+    private
+
+    def set_defaults
+        self.name ||= "guest"
+        self.personality ||= :neutral
+        self.preference  ||= :both
+    end
+end

--- a/back/db/migrate/20251212074737_create_users.rb
+++ b/back/db/migrate/20251212074737_create_users.rb
@@ -1,0 +1,12 @@
+class CreateUsers < ActiveRecord::Migration[8.0]
+  def change
+    create_table :users do |t|
+      t.string  :name,        null: true,  default: "guest"
+      t.integer :personality, null: false, default: 1
+      t.integer :preference,  null: false, default: 1
+
+
+      t.timestamps
+    end
+  end
+end

--- a/back/db/migrate/20251212085235_create_recipes.rb
+++ b/back/db/migrate/20251212085235_create_recipes.rb
@@ -1,0 +1,11 @@
+class CreateRecipes < ActiveRecord::Migration[8.0]
+  def change
+    create_table :recipes do |t|
+      t.string  :title, null: false
+      t.integer :category, null: false
+      t.text    :description, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/back/db/migrate/20251212162443_create_activity_logs.rb
+++ b/back/db/migrate/20251212162443_create_activity_logs.rb
@@ -1,0 +1,15 @@
+class CreateActivityLogs < ActiveRecord::Migration[8.0]
+  def change
+    create_table :activity_logs do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :recipe, null: false, foreign_key: true
+      t.integer :mood, null: false
+      t.integer :feedback, null: false, default: 1
+      t.integer :weather, null: false
+      t.integer :duration_min, null: false
+
+      t.timestamps
+    end
+  end
+end
+

--- a/back/db/schema.rb
+++ b/back/db/schema.rb
@@ -1,0 +1,45 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[8.0].define(version: 2025_12_12_162443) do
+  create_table "activity_logs", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.integer "recipe_id", null: false
+    t.integer "mood"
+    t.integer "feedback"
+    t.integer "weather"
+    t.integer "duration_min"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["recipe_id"], name: "index_activity_logs_on_recipe_id"
+    t.index ["user_id"], name: "index_activity_logs_on_user_id"
+  end
+
+  create_table "recipes", force: :cascade do |t|
+    t.string "title"
+    t.integer "category"
+    t.text "description"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "name"
+    t.integer "personality"
+    t.integer "preference"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  add_foreign_key "activity_logs", "recipes"
+  add_foreign_key "activity_logs", "users"
+end

--- a/back/test/fixtures/activity_logs.yml
+++ b/back/test/fixtures/activity_logs.yml
@@ -1,0 +1,17 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  recipe: one
+  mood: 1
+  feedback: 1
+  weather: 1
+  duration_min: 1
+
+two:
+  user: two
+  recipe: two
+  mood: 1
+  feedback: 1
+  weather: 1
+  duration_min: 1

--- a/back/test/fixtures/recipes.yml
+++ b/back/test/fixtures/recipes.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  title: MyString
+  category: 1
+  description: MyText
+
+two:
+  title: MyString
+  category: 1
+  description: MyText

--- a/back/test/fixtures/users.yml
+++ b/back/test/fixtures/users.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+  personality: 1
+  preference: 1
+
+two:
+  name: MyString
+  personality: 1
+  preference: 1

--- a/back/test/models/activity_log_test.rb
+++ b/back/test/models/activity_log_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ActivityLogTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/back/test/models/recipe_test.rb
+++ b/back/test/models/recipe_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class RecipeTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/back/test/models/user_test.rb
+++ b/back/test/models/user_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class UserTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# PR: Add core DB schema + enums/defaults for Aima v1

## Summary
Aima v1 のMVPに必要な **DBスキーマ（User / Recipe / ActivityLog）** を追加し、enum運用・デフォルト値設定で安定してレコード作成できる状態にしました。

- Users / Recipes / ActivityLogs のテーブル作成
- enum（int）運用のための model 定義追加
- `before_validation` によるデフォルト補完（User / ActivityLog）
- 関連（User ↔ ActivityLog ↔ Recipe）を設定

## Background / Why
- v1では「レシピ提案 → 選択 → フィードバック → 履歴表示」を最短で実装するため、まず **永続化の土台** が必要。
- enumはDBではintで持ちつつ、アプリ側では意味のある値（`relax`, `neutral` 等）で扱いたい。
- `create!` 実行時に nil が入り得る項目（Userの設定値、ActivityLogのfeedback）を **モデル側で補完**し、バリデーションと整合させる。

## Changes
### DB / Migrations
- `users`
  - `name`（default: "guest" 想定）
  - `personality`（enum int）
  - `preference`（enum int）
- `recipes`
  - `title` / `category`（enum int）/ `description`
- `activity_logs`
  - `user_id` / `recipe_id`（references）
  - `mood` / `feedback` / `weather`（enum int）
  - `duration_min`

### Models
- `User`
  - `enum personality`, `enum preference`
  - `before_validation :set_defaults`（guest / neutral / both）
  - `has_many :activity_logs`
- `Recipe`
  - `enum category`（relax/focus/outdoor/reflect/play）
  - `has_many :activity_logs`
- `ActivityLog`
  - `enum mood`, `enum feedback`, `enum weather`
  - `before_validation :set_defaults`（feedback: normal）
  - `belongs_to :user`, `belongs_to :recipe`

## Verification
Rails console で以下を確認済み：

- enum が定義されていること
  - `User.personalities`, `User.preferences`, `Recipe.categories`
  - `ActivityLog.moods`, `ActivityLog.feedbacks`, `ActivityLog.weathers`
- レコード作成・関連が動作すること
  - `User.create!` が default 補完で作成できる
  - `Recipe.create!(title:, category:, description:)` が作成できる
  - `ActivityLog.create!(user:, recipe:, mood:, weather:, duration_min:)` が作成でき、`feedback` は default 補完される
  - `log.recipe.title` で関連が辿れる

## Notes / Follow-ups
- v1では `executed_at` は持たず `created_at` を実行タイミングとして扱う（将来必要なら v2 で追加）。
- 次PRで `db/seeds.rb` に category 別の seed レシピ投入を行い、Recommendation の仮実装（DBから3件返す）に繋げる。
