### PR TITLE
feat: add POST /api/v1/recommendations endpoint

### DIFF
--- a/back/app/controllers/api/v1/recommendations_controller.rb
+++ b/back/app/controllers/api/v1/recommendations_controller.rb
@@ -1,0 +1,40 @@
+module Api
+  module V1
+    class RecommendationsController < ApplicationController
+      def create
+        mood        = params.require(:mood)
+        duration_min = params.require(:duration_min).to_i
+        weather     = params.require(:weather)
+
+        # v1: まずは超単純マップ（後でAIに差し替え）
+        category = pick_category(mood)
+
+        recipes = Recipe.where(category: category)
+                        .order("RANDOM()")
+                        .limit(3)
+
+        # 候補が足りないときの保険（基本seedで起きない想定）
+        if recipes.size < 3
+          recipes = Recipe.order("RANDOM()").limit(3)
+        end
+
+        render json: {
+          input: { mood: mood, duration_min: duration_min, weather: weather, category: category },
+          recommendations: recipes.as_json(only: [:id, :title, :description, :category])
+        }, status: :created
+      end
+
+      private
+
+      def pick_category(mood)
+        # mood は enum の文字列を想定: energetic / neutral / calm
+        case mood
+        when "energetic" then :outdoor
+        when "neutral"   then :focus
+        when "calm"      then :relax
+        else :relax
+        end
+      end
+    end
+  end
+end

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       get "health", to: "health#show"
+      resources :recommendations, only: :create
     end
   end
 

--- a/back/test/controllers/api/v1/recommendations_controller_test.rb
+++ b/back/test/controllers/api/v1/recommendations_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class Api::V1::RecommendationsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要
ユーザーの mood / duration_min / weather を受け取り、
それに応じたレシピ3件を返す Recommendations API（v1）を実装しました。

## 追加した内容
- `POST /api/v1/recommendations` のルーティングを追加
- `Api::V1::RecommendationsController#create` を新規作成
- mood → category の簡易マッピングロジックを `pick_category` として実装
- カテゴリ別にランダムで3件のレシピを返すロジックを実装
- fallback として、該当カテゴリが不足した場合は全カテゴリから3件取得する処理を追加

## 動作確認
以下の curl コマンドで正常にレスポンスが返ることを確認済み：

```bash
curl -X POST http://localhost:3000/api/v1/recommendations \
  -H "Content-Type: application/json" \
  -d '{"mood":"calm","duration_min":30,"weather":"sunny"}'
