### PR TITLE
feat: add activity log create endpoint

### DIFF
--- a/back/app/controllers/api/v1/activity_logs_controller.rb
+++ b/back/app/controllers/api/v1/activity_logs_controller.rb
@@ -1,0 +1,61 @@
+module Api
+  module V1
+    class ActivityLogsController < ApplicationController
+      def create
+        user = User.first! # v1: 認証なしなので固定ユーザーでOK（seedの User.create! を想定）
+
+        recipe = resolve_recipe!
+
+        log = ActivityLog.create!(
+          user: user,
+          recipe: recipe,
+          mood: activity_log_params[:mood],
+          duration_min: activity_log_params[:duration_min].to_i,
+          weather: activity_log_params[:weather],
+          feedback: activity_log_params[:feedback] # 任意（nilなら before_validation で normal ）
+        )
+
+        render json: serialize_log(log), status: :created
+      end
+
+      private
+
+      # 既存seedの recipe_id でログを作る or AI生成レシピを新規保存してログを作る
+      def resolve_recipe!
+        if activity_log_params[:recipe_id].present?
+          Recipe.find(activity_log_params[:recipe_id])
+        else
+          Recipe.create!(
+            title: activity_log_params.require(:title),
+            category: activity_log_params.require(:category),
+            description: activity_log_params.require(:description)
+          )
+        end
+      end
+
+      def activity_log_params
+        params.require(:activity_log).permit(
+          :recipe_id,
+          :title, :category, :description,
+          :mood, :duration_min, :weather, :feedback
+        )
+      end
+
+      def serialize_log(log)
+        {
+          id: log.id,
+          user_id: log.user_id,
+          recipe_id: log.recipe_id,
+          recipe_title: log.recipe.title,
+          recipe_category: log.recipe.category,
+          description: log.recipe.description,
+          mood: log.mood,
+          feedback: log.feedback,
+          duration_min: log.duration_min,
+          weather: log.weather,
+          executed_at: log.created_at.iso8601
+        }
+      end
+    end
+  end
+end

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -8,7 +8,8 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       get "health", to: "health#show"
-      resources :recommendations, only: :create
+      resources :recommendations, only: [:create]
+      resources :activity_logs, only: [:create]
     end
   end
 

--- a/back/test/controllers/api/v1/activity_logs_controller_test.rb
+++ b/back/test/controllers/api/v1/activity_logs_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class Api::V1::ActivityLogsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# PR: Add ActivityLog create API (POST)

## Summary
Aima v1 において、**ユーザーが選択したレシピを実行ログとして保存するAPI**を実装しました。

- `POST /api/v1/activity_logs` を追加
- seed レシピ／AI生成レシピのどちらにも対応
- レシピは「選択されたタイミング」でのみ永続化

## Background / Why
- AI生成レシピは一時データとし、DBには保存しない方針
- 実際に「選ばれた」行動のみを価値あるデータとして残したい
- v1では認証を入れず、固定ユーザーでログを作成することで実装速度を優先

## Implementation
### API
- **POST `/api/v1/activity_logs`**
  - 入力
    - `recipe_id`（既存レシピを選択した場合）
    - または `title / category / description`（AI生成レシピ）
    - `mood / duration_min / weather / feedback（任意）`
  - 出力
    - 作成された ActivityLog と関連する Recipe 情報

### Behavior
- `recipe_id` がある場合：既存 Recipe を参照
- `recipe_id` がない場合：新規 Recipe を作成してから ActivityLog を作成
- `feedback` が未指定の場合は model の default が適用される

## Verification
以下を確認済み：

- seed レシピを選択した場合に ActivityLog が作成される
- AI生成レシピ（recipe_id なし）でも Recipe + ActivityLog が作成される
- レスポンスが 201 Created で返る
- ActivityLog と Recipe の関連が正しく保存されている

## Notes / Follow-ups
- v1では固定ユーザー（認証なし）で運用
- 次のPRで `GET /api/v1/activity_logs` を追加し、履歴一覧を取得可能にする予定
- v2以降で認証・ユーザー切り替えを導入予定
