### PR TITLE
feat:API疎通の実装

### DIFF
--- a/aima-front/README.md
+++ b/aima-front/README.md
@@ -2,7 +2,7 @@ nodejs:  v24.11.1
 
 
 インストール：npx create-next-app aima-front
-npm install -D tailwindcss postcss autoprefixer
+ npm i -D tailwindcss
 
 
 "next": "16.0.7",

--- a/aima-front/app/api/v1/activity_logs/route.ts
+++ b/aima-front/app/api/v1/activity_logs/route.ts
@@ -1,0 +1,61 @@
+// app/api/v1/activity_logs/route.ts
+import { NextRequest, NextResponse } from "next/server";
+
+// Rails 側のベースURL（.env.local で上書き可）
+const BACKEND_BASE =
+  process.env.BACKEND_BASE_URL ?? "http://localhost:3001";
+
+export async function GET(_req: NextRequest) {
+  const backendUrl = `${BACKEND_BASE}/api/v1/activity_logs`;
+
+  const res = await fetch(backendUrl, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    cache: "no-store",
+  });
+
+  const text = await res.text();
+
+  if (!res.ok) {
+    console.error("backend GET /activity_logs error", res.status, text);
+    // Rails からのエラー内容をそのまま返す
+    return new NextResponse(text, { status: res.status });
+  }
+
+  return new NextResponse(text, {
+    status: res.status,
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+}
+
+export async function POST(req: NextRequest) {
+  const body = await req.text(); // そのままパススルー
+
+  const backendUrl = `${BACKEND_BASE}/api/v1/activity_logs`;
+
+  const res = await fetch(backendUrl, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body,
+  });
+
+  const text = await res.text();
+
+  if (!res.ok) {
+    console.error("backend POST /activity_logs error", res.status, text);
+    return new NextResponse(text, { status: res.status });
+  }
+
+  return new NextResponse(text, {
+    status: res.status,
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+}

--- a/aima-front/app/api/v1/recommendations/route.ts
+++ b/aima-front/app/api/v1/recommendations/route.ts
@@ -1,0 +1,51 @@
+// app/api/v1/recommendations/route.ts
+import { NextResponse } from "next/server";
+
+const RAW_BACKEND_BASE = process.env.BACKEND_API_BASE_URL;
+const BACKEND_BASE =
+  RAW_BACKEND_BASE && RAW_BACKEND_BASE.trim().length > 0
+    ? RAW_BACKEND_BASE.trim()
+    : "http://localhost:3001"; // Rails 用のデフォルト
+
+export async function POST(req: Request) {
+  try {
+    // フロントから来た JSON をそのまま Rails に中継したいので text として読む
+    const bodyText = await req.text();
+
+    const backendRes = await fetch(`${BACKEND_BASE}/api/v1/recommendations`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: bodyText,
+    });
+
+    const text = await backendRes.text();
+
+    if (!backendRes.ok) {
+      console.error(
+        "[recommendations route] backend error",
+        backendRes.status,
+        text
+      );
+      return new NextResponse(text || "backend error", {
+        status: backendRes.status,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    return new NextResponse(text, {
+      status: backendRes.status,
+      headers: {
+        "Content-Type":
+          backendRes.headers.get("content-type") || "application/json",
+      },
+    });
+  } catch (e) {
+    console.error("[recommendations route] proxy error", e);
+    return NextResponse.json(
+      { error: "proxy error", detail: String(e) },
+      { status: 500 }
+    );
+  }
+}

--- a/aima-front/app/recipes/loading.tsx
+++ b/aima-front/app/recipes/loading.tsx
@@ -1,0 +1,11 @@
+// app/recipes/loading.tsx
+import { LoadingCard } from "@/components/ui/LoadingCard";
+
+export default function Loading() {
+  return (
+    <LoadingCard
+      title="RECIPE"
+      message="おすすめレシピを準備しています…"
+    />
+  );
+}

--- a/aima-front/app/select/page.tsx
+++ b/aima-front/app/select/page.tsx
@@ -41,7 +41,7 @@ export default function SelectPage() {
           {/* STEP 1 */}
           <section className="space-y-2">
             <p className="step-label">STEP 1</p>
-            <p className="step-text">今の余白時間はどれくらい？</p>
+            <p className="step-text">今、どれくらい時間ある？</p>
 
             <OptionGrid
               options={timeOptions.map((t) => ({ id: t, label: `${t}分` }))}

--- a/aima-front/components/ui/LoadingCard.tsx
+++ b/aima-front/components/ui/LoadingCard.tsx
@@ -1,0 +1,15 @@
+// components/ui/LoadingCard.tsx
+export function LoadingCard({
+  title,
+  message,
+}: {
+  title: string;
+  message: string;
+}) {
+  return (
+    <div className="rounded-3xl bg-card-bg px-6 py-8 text-center">
+      <p className="tracking-[0.25em] text-text-accent text-xs">{title}</p>
+      <p className="mt-2 text-sm text-text-main/80">{message}</p>
+    </div>
+  );
+}

--- a/aima-front/components/ui/PageShell.tsx
+++ b/aima-front/components/ui/PageShell.tsx
@@ -11,7 +11,7 @@ export function PageShell({ children, className = "" }: PageShellProps) {
   return (
     <main
       className={[
-        "min-h-screen bg-gradient-to-b from-bg-grad-start via-bg-grad-mid to-bg-grad-end flex items-center justify-center px-4 py-10",
+        "min-h-screen bg-gradient-to-b from-bg-grad-start via-bg-grad-mid to-bg-grad-end flex items-center justify-center px-4 py-10 sm:py-14 lg:py-12",
         className,
       ].join(" ")}
     >

--- a/aima-front/components/ui/Pageshell.tsx
+++ b/aima-front/components/ui/Pageshell.tsx
@@ -1,0 +1,4 @@
+// Deprecated duplicate file. PageShell is defined in PageShell.tsx
+// This file intentionally left empty to avoid duplicate-export TypeScript errors.
+
+export {};

--- a/aima-front/lib/options.ts
+++ b/aima-front/lib/options.ts
@@ -1,4 +1,4 @@
-// lib/options.ts
+// lib/options.ts１
 import type { Personality, Preference, Mood, Weather } from "./types";
 
 export const timeOptions = [15, 30, 60] as const;

--- a/aima-front/treelog.txt
+++ b/aima-front/treelog.txt
@@ -1,0 +1,3 @@
+=  [error opening dir]
+
+0 directories, 0 files

--- a/aima-front/tsconfig.json
+++ b/aima-front/tsconfig.json
@@ -30,5 +30,5 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "components/ui/Pageshell.tsx"]
 }

--- a/aima-front/types/route-jss.d.ts
+++ b/aima-front/types/route-jss.d.ts
@@ -11,3 +11,14 @@ declare module "../../../app/nextapi/route.jss" {
   const mod: any;
   export = mod;
 }
+
+// Cover malformed generated import paths seen in .next types (eg: route.jsdations/...)
+declare module "*recommendations/route.jsdations/route.js" {
+  const mod: any;
+  export = mod;
+}
+
+declare module "app/api/v1/recommendations/route.jsdations/route.js" {
+  const mod: any;
+  export = mod;
+}


### PR DESCRIPTION
概要（Summary）

本PRでは、Aima フロントエンドにおいて
API連携を前提とした画面構成・状態管理・ローディング設計の整理を行いました。

Rails API が未完成な状態でも開発を進められるよう、
モック切り替えを含む API 層の整備と、
ユーザー体験を意識した画面遷移・ローディング UI の実装を行っています。

対応内容（What was done）
1. API連携の整理（lib/api.ts）
API呼び出しを requestJson に集約
NEXT_PUBLIC_USE_MOCK による モック / 実API 切り替えを実装

以下のAPIをフロントから利用可能に

POST /users（ユーザー登録）
POST /recommendations（レシピ生成）
POST /activity_logs（レビュー保存）
GET /activity_logs（履歴取得）


2. ユーザー状態の扱い（userStore）
ユーザーIDを LocalStorage に保存
初回アクセス時は /onboarding にリダイレクト
ログアウト時はユーザーIDを削除し再オンボーディング
getUserId()
setUserId(id)
clearUserId()

👉 ログイン不要・軽量なユーザー固定設計

3. 画面遷移フローの確立
/onboarding
   ↓
/ (Home)
   ↓
/select
   ↓
/recipes
   ↓
/review
   ↓
/history
URL Query を使って状態を受け渡し
ページリロードしても状態が復元可能

4. ローディング設計の分離（重要）
ローディングを 用途別に3種類に分けて実装：
種類	使用箇所	状態
ページローディング	recipes / history	API取得中
アクションローディング	レシピ決定ボタン	遷移中
送信ローディング	review	保存中
PageShell + LoadingCard による共通UI
二重送信・多重遷移を防止

5. UIコンポーネントの共通化
以下を 責務ごとに分離：

PageShell：画面全体のレイアウト
Card：コンテンツ領域
OptionGrid / SelectOption：選択UI
LoadingCard：ローディング表示


6. 型安全性の担保（TypeScript）
Mood / DurationMin / Feedback / Personality / Preference を union 型で定義
URLパラメータは parse 関数で正規化
APIレスポンス型を厳密に指定