### PR TITLE
chore: フロントエンドのdockerfile作成 #33

### DIFF
--- a/aima-front/.dockerignore
+++ b/aima-front/.dockerignore
@@ -1,0 +1,8 @@
+node_modules
+
+.env
+.env.local
+
+.git
+Dockerfile
+.dockerignore

--- a/aima-front/Dockerfile
+++ b/aima-front/Dockerfile
@@ -1,0 +1,49 @@
+FROM node:24-alpine AS base
+
+FROM base AS deps
+
+RUN apk add --no-cache libc6-compat
+WORKDIR /app
+
+COPY package.json yarn.lock* package-lock.json pnpm-lock.yaml* .npmrc* ./
+
+RUN \
+    if [ -f yarn.lock ]; then yarn --frozen-lockfile; \
+    elif [ -f package-lock.json ]; then npm ci; \
+    elif [ -f pnpm-lock.yaml ]; then corepack enable pnpm && pnpm i --frozen-lockfile; \
+    else echo "Lockfile not found." && exit 1; \
+    fi
+
+FROM base AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+
+RUN \
+    if [ -f yarn.lock ]; then yarn run build; \
+    elif [ -f package-lock.json ]; then npm run build; \
+    elif [ -f pnpm-lock.json ]; then corepack enable pnpm && pnpm run build; \
+    else echo "Lockfile not found." && exit 1; \
+    fi
+
+FROM base AS runner
+WORKDIR /app
+
+ENV NODE_ENV=production
+
+RUN addgroup --system --gid 1001 nodejs
+RUN adduser --system --uid 1001 nextjs
+
+
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+USER nextjs
+
+EXPOSE 3001
+
+ENV PORT=3001
+
+ENV HOSTNAME="0.0.0.0"
+CMD ["node","server.js"]

--- a/aima-front/next.config.ts
+++ b/aima-front/next.config.ts
@@ -2,6 +2,7 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   /* config options here */
+  output: 'standalone',
 };
 
 export default nextConfig;


### PR DESCRIPTION
## 概要
フロントエンドの実行環境を構築するdockerfileの作成をしました
## 変更内容
next.config.tsの編集
ベースイメージ: AIplane
dockerignoreの追加

## 実行手順
`docker build -t aima-front .`
`docker run -p 3001:3001 aima-front`