### PR TITLE
fix:useEffect内でuseStateを使った関数を使っていた問題の修正　#60

### DIFF
--- a/aima-front/app/history/page.tsx
+++ b/aima-front/app/history/page.tsx
@@ -25,7 +25,6 @@ export default function HistoryPage() {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-  
     getActivityLogs(100)
       .then(({ activity_logs }) => setLogs(activity_logs))
       .catch((e) => {

--- a/aima-front/app/history/page.tsx
+++ b/aima-front/app/history/page.tsx
@@ -25,9 +25,7 @@ export default function HistoryPage() {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    setLoading(true);
-    setError(null);
-
+  
     getActivityLogs(100)
       .then(({ activity_logs }) => setLogs(activity_logs))
       .catch((e) => {

--- a/aima-front/app/page.tsx
+++ b/aima-front/app/page.tsx
@@ -10,12 +10,24 @@ export default function HomePage() {
   const [checked, setChecked] = useState(false);
 
   useEffect(() => {
-    const id = getUserId();
-    if (!id) {
-      router.replace("/onboarding");
-      return;
-    }
-    setChecked(true);
+    let cancelled = false;
+
+    const checkAuth = async () => {
+      const id = await getUserId();
+      if (!id) {
+        router.replace("/onboarding");
+        return;
+      }
+      if (!cancelled) {
+        setChecked(true);
+      }
+    };
+
+    void checkAuth();
+
+    return () => {
+      cancelled = true;
+    };
   }, [router]);
 
   const handleLogout = () => {

--- a/aima-front/app/recipes/page.tsx
+++ b/aima-front/app/recipes/page.tsx
@@ -4,7 +4,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { createRecommendation } from "@/lib/api";
-import type { Recipe, DurationMin, Mood } from "@/lib/types";
+import type { Recipe, DurationMin, Mood, Weather } from "@/lib/types";
 
 function parseDuration(v: string | null): DurationMin {
   const n = Number(v);
@@ -12,6 +12,9 @@ function parseDuration(v: string | null): DurationMin {
 }
 function parseMood(v: string | null): Mood {
   return v === "energetic" || v === "neutral" || v === "calm" ? v : "neutral";
+}
+function parseWeather(v: string | null): Weather {
+  return v === "sunny" || v === "rainy" || v === "cloudy" ? v : "sunny";
 }
 
 const moodLabel: Record<Mood, string> = {
@@ -30,10 +33,7 @@ export default function RecipesPage() {
     [params]
   );
   const mood = useMemo(() => parseMood(params.get("mood")), [params]);
-  const weather = useMemo(
-    () => (params.get("weather") as import("@/lib/types").Weather) ?? "sunny",
-    [params]
-  );
+  const weather = useMemo(() => parseWeather(params.get("weather")), [params]);
 
   const [recipes, setRecipes] = useState<Recipe[]>([]);
   const [loading, setLoading] = useState(true);
@@ -43,28 +43,33 @@ export default function RecipesPage() {
   useEffect(() => {
     let cancelled = false;
 
-    setLoading(true);
-    setError(null);
-    setSelectedRecipeId(null);
+    const fetchRecipes = async () => {
+      setLoading(true);
+      setError(null);
+      setSelectedRecipeId(null);
 
-    createRecommendation({ duration_min: duration, mood, weather })
-      .then((res) => {
-        if (cancelled) return;
-        setRecipes(res.recipes);
-      })
-      .catch(() => {
-        if (cancelled) return;
-        setError("レシピの取得に失敗しました");
-      })
-      .finally(() => {
-        if (cancelled) return;
-        setLoading(false);
-      });
+      try {
+        const res = await createRecommendation({ duration_min: duration, mood, weather });
+        if (!cancelled) {
+          setRecipes(res.recipes);
+        }
+      } catch {
+        if (!cancelled) {
+          setError("レシピの取得に失敗しました");
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    };
+
+    void fetchRecipes();
 
     return () => {
       cancelled = true;
     };
-  }, [duration, mood]);
+  }, [duration, mood, weather]);
 
   const goReview = () => {
     if (!selectedRecipeId) return;


### PR DESCRIPTION
`app/history/page.tsx`　のseEffect内でUsestateを同期呼び出ししていたため、余計なレンダリングが発生してしまう問題の修正。

## 修正内容
`app/history/page.tsx`
useEffect冒頭の不要な初期化ようのuseStateの削除

`app/page.tsx`
UserIdをDBで管理することを見越してuseEffect内の処理を非同期の関数に閉じ込めました



